### PR TITLE
Add travis CI configuration for the SeRoNet installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: bash
 
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      sudo: required
+    - os: linux
+      dist: bionic
+      sudo: required
 before_install:
   - sudo apt-get -y install zenity
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: bash
 before_install:
   - sudo apt-get -y install zenity
 script:
-  - bash SeRoNet-Infrastructure-Installer-v1.0.sh
+  - bash SeRoNet-Infrastructure-Installer-v1.0.sh non-visual-installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: bash
+
+before_install:
+  - sudo apt-get -y install zenity
+script:
+  - bash SeRoNet-Infrastructure-Installer-v1.0.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
 before_install:
   - sudo apt-get -y install zenity
 script:
-  - bash SeRoNet-Infrastructure-Installer-v1.0.sh non-visual-installation
+  - bash SeRoNet-Infrastructure-Installer-latest.sh non-visual-installation

--- a/SeRoNet-Infrastructure-Installer-v1.0.sh
+++ b/SeRoNet-Infrastructure-Installer-v1.0.sh
@@ -525,4 +525,24 @@ ros)
 	fi
 ;;
 
+###############################################################################
+non-visual-installation)
+
+	CURRENT_ACTION_NUMBER=$((0))
+	ACTIONS="ace-smartsoft opcua-backend opcua-devices ros"
+	SELECTED_ACTIONS_COUNTER=4
+	for CURR_ACTION in $ACTIONS; do
+	    # execute the next action
+	    echo "#### Execute installation step $CURR_ACTION ####"
+	    bash $SCRIPT_NAME $CURR_ACTION $INSTALLATION_DIR $LOGFILE $CURRENT_ACTION_NUMBER $SELECTED_ACTIONS_COUNTER
+	    # abort executing further commands if the previos command returned with != 0
+	    if [ $? -ne 0 ]; then
+	      exit $?
+	    fi
+	    # calculate the progress percentage number and print it to the /tmp/install-msg.log
+	    CURRENT_ACTION_NUMBER=$(($CURRENT_ACTION_NUMBER + 1))
+	    awk "BEGIN { print $CURRENT_ACTION_NUMBER/$SELECTED_ACTIONS_COUNTER*100 }" >> /tmp/install-msg.log
+	done
+;;
+
 esac


### PR DESCRIPTION
To ease the debug and test of the installation script I added a travis configuration that automatically test the installation script for linux 16.04 and 18.04. The tests are still not complete (I removed all the visual tools for now) but I think it is a good starting point. 

results: https://www.travis-ci.org/ipa-nhg/SeRoNet-Installer